### PR TITLE
Add github to required providers

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -16,4 +16,10 @@
 
 terraform {
   required_version = ">= 0.12.6"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.15.1"
+    }
+  }
 }


### PR DESCRIPTION
Adds `integrations/github` to the module's required provider.
`4.15.1` has a hotfix for an issue that surfaced with 4.15 and was impacting root modules with a `~> 4` version requirement