### PR TITLE
Update generate_key test to properly address GH secret array

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ locals {
       ]
     ]
   ])
-  generate_key = var.generate_key || var.gke_secret_create != null || var.github_secret_create != null
+  generate_key = var.generate_key || var.gke_secret_create != null || length(var.github_secret_create) > 0
   # https://github.com/hashicorp/terraform/issues/22405#issuecomment-591917758
   key = try(
     local.generate_key


### PR DESCRIPTION
A previous update to this module changed the `github_secret_create` to be an array of values instead of a singular object.  However, this check wasn't updated as well, causing service account keys to be created every time.  This fixes that glitch.