### PR TITLE
Add Github workload identity federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,33 +22,74 @@ module "myproject-default-service-accounts" {
     ]
   }
 }
-# tftest:modules=1:resources=5
 ```
 
-<!-- BEGIN TFDOC -->
-## Variables
+## Requirements
 
-| name | description | type | required | default |
-|---|---|:---: |:---:|:---:|
-| name | Name of the service account to create. | <code title="">string</code> | ✓ |  |
-| project_id | Project id where service account will be created. | <code title="">string</code> | ✓ |  |
-| *display_name* | Display name of the service account to create. | <code title="">string</code> |  | <code title="">Terraform-managed.</code> |
-| *generate_key* | Generate a key for service account. | <code title="">bool</code> |  | <code title="">false</code> |
-| *iam* | IAM bindings on the service account in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
-| *iam_billing_roles* | Project roles granted to the service account, by billing account id. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
-| *iam_folder_roles* | Project roles granted to the service account, by folder id. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
-| *iam_organization_roles* | Project roles granted to the service account, by organization id. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
-| *iam_project_roles* | Project roles granted to the service account, by project id. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
-| *iam_storage_roles* | Storage roles granted to the service account, by bucket name. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
-| *prefix* | Prefix applied to service account names. | <code title="">string</code> |  | <code title="">null</code> |
-| *service_account_create* | Create service account. When set to false, uses a data source to reference an existing service account. | <code title="">bool</code> |  | <code title="">true</code> |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.8 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.15.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.8 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [github](#provider\_github) | >= 4.15.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.8 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [github_actions_secret.repository_secret](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
+| [google-beta_google_iam_workload_identity_pool.github_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool) | resource |
+| [google-beta_google_iam_workload_identity_pool_provider.provider](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool_provider) | resource |
+| [google_billing_account_iam_member.billing-roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_account_iam_member) | resource |
+| [google_folder_iam_member.folder-roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_organization_iam_member.organization-roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_project_iam_member.project-roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_binding.roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_member.github_service_account_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_key.key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
+| [google_storage_bucket_iam_member.bucket-roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [kubernetes_secret.service-account-key-secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [google_service_account.service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | Display name of the service account to create. | `string` | `"Terraform-managed."` | no |
+| <a name="input_generate_key"></a> [generate\_key](#input\_generate\_key) | Generate a key for service account. | `bool` | `false` | no |
+| <a name="input_github_secret_create"></a> [github\_secret\_create](#input\_github\_secret\_create) | Create a Github Actions secret containing this service account's key | <pre>list(object({<br>    repository = string<br>    name       = string<br>  }))</pre> | `[]` | no |
+| <a name="input_github_workload_identity_federation"></a> [github\_workload\_identity\_federation](#input\_github\_workload\_identity\_federation) | Workload identity federation configs for Github Actions | <pre>object({<br>    environment = string<br>    repository  = string<br>  })</pre> | `null` | no |
+| <a name="input_gke_secret_create"></a> [gke\_secret\_create](#input\_gke\_secret\_create) | Create GKE Opaque secret containing this service account's key as key.json | <pre>object({<br>    namespace = string<br>  })</pre> | `null` | no |
+| <a name="input_iam"></a> [iam](#input\_iam) | IAM bindings on the service account in {ROLE => [MEMBERS]} format. | `map(list(string))` | `{}` | no |
+| <a name="input_iam_billing_roles"></a> [iam\_billing\_roles](#input\_iam\_billing\_roles) | Project roles granted to the service account, by billing account id. | `map(list(string))` | `{}` | no |
+| <a name="input_iam_folder_roles"></a> [iam\_folder\_roles](#input\_iam\_folder\_roles) | Project roles granted to the service account, by folder id. | `map(list(string))` | `{}` | no |
+| <a name="input_iam_organization_roles"></a> [iam\_organization\_roles](#input\_iam\_organization\_roles) | Project roles granted to the service account, by organization id. | `map(list(string))` | `{}` | no |
+| <a name="input_iam_project_roles"></a> [iam\_project\_roles](#input\_iam\_project\_roles) | Project roles granted to the service account, by project id. | `map(list(string))` | `{}` | no |
+| <a name="input_iam_storage_roles"></a> [iam\_storage\_roles](#input\_iam\_storage\_roles) | Storage roles granted to the service account, by bucket name. | `map(list(string))` | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the service account to create. | `string` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix applied to service account names. | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id where service account will be created. | `string` | n/a | yes |
+| <a name="input_service_account_create"></a> [service\_account\_create](#input\_service\_account\_create) | Create service account. When set to false, uses a data source to reference an existing service account. | `bool` | `true` | no |
 
 ## Outputs
 
-| name | description | sensitive |
-|---|---|:---:|
-| email | Service account email. |  |
-| iam_email | IAM-format service account email. |  |
-| key | Service account key. | ✓ |
-| service_account | Service account resource. |  |
-<!-- END TFDOC -->
+| Name | Description |
+|------|-------------|
+| <a name="output_email"></a> [email](#output\_email) | Service account email. |
+| <a name="output_github_pool_provider_id"></a> [github\_pool\_provider\_id](#output\_github\_pool\_provider\_id) | Identifier for the Github provider |
+| <a name="output_iam_email"></a> [iam\_email](#output\_iam\_email) | IAM-format service account email. |
+| <a name="output_key"></a> [key](#output\_key) | Service account key. |
+| <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Service account resource. |

--- a/header.md
+++ b/header.md
@@ -1,0 +1,25 @@
+# Google Service Account Module
+
+This module allows simplified creation and management of one a service account and its IAM bindings. A key can optionally be generated and will be stored in Terraform state. To use it create a sensitive output in your root modules referencing the `key` output, then extract the private key from the JSON formatted outputs.
+
+## Example
+
+```hcl
+module "myproject-default-service-accounts" {
+  source            = "github.com/dapperlabs-platform/terraform-google-iam-service-account?ref=tag"
+  project_id        = "myproject"
+  name              = "vm-default"
+  generate_key      = true
+  # authoritative roles granted *on* the service accounts to other identities
+  iam       = {
+    "roles/iam.serviceAccountUser" = ["user:foo@example.com"]
+  }
+  # non-authoritative roles granted *to* the service accounts on other resources
+  iam_project_roles = {
+    "myproject" = [
+      "roles/logging.logWriter",
+      "roles/monitoring.metricWriter",
+    ]
+  }
+}
+```

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+data "google_project" "project" {
+}
+
 output "service_account" {
   description = "Service account resource."
   value       = local.service_account
@@ -39,4 +42,9 @@ output "key" {
   description = "Service account key."
   sensitive   = true
   value       = local.key
+}
+
+output "github_pool_provider_id" {
+  description = "Identifier for the Github provider"
+  value       = local.add_github_workload_identity_federation ? replace(google_iam_workload_identity_pool_provider.provider[0].id, var.project_id, data.google_project.project.number) : ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -100,3 +100,12 @@ variable "github_secret_create" {
   }))
   default = []
 }
+
+variable "github_workload_identity_federation" {
+  description = "Workload identity federation configs for Github Actions"
+  type = object({
+    environment = string
+    repository  = string
+  })
+  default = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.3.8"
   required_providers {
     github = {
       source  = "integrations/github"

--- a/workload-identity-federation.tf
+++ b/workload-identity-federation.tf
@@ -1,0 +1,51 @@
+locals {
+  add_github_workload_identity_federation = var.github_workload_identity_federation != null
+  # repository-service-account-name
+  github_pool_id     = substr("${split("/", var.github_workload_identity_federation.repository)[1]}-${var.name}", 0, 32)
+  github_repository  = var.github_workload_identity_federation.repository
+  github_environment = var.github_workload_identity_federation.environment
+  # only allow workflows from this repository/environment combination to impersonate this service account
+  github_attribute_condition = "assertion.repository == \"${local.github_repository}\" && assertion.environment == \"${local.github_environment}\""
+  github_issuer_uri          = "https://token.actions.githubusercontent.com"
+}
+
+resource "google_iam_workload_identity_pool" "github_pool" {
+  count    = local.add_github_workload_identity_federation ? 1 : 0
+  provider = google-beta
+
+  project                   = var.project_id
+  workload_identity_pool_id = local.github_pool_id
+  display_name              = local.github_pool_id
+  description               = "Workload Identity Federation Pool managed by Terraform"
+  disabled                  = false
+}
+
+resource "google_iam_workload_identity_pool_provider" "provider" {
+  count    = local.add_github_workload_identity_federation ? 1 : 0
+  provider = google-beta
+
+  project                            = var.project_id
+  attribute_condition                = local.github_attribute_condition
+  description                        = "Workload Identity Federation Pool Provider managed by Terraform"
+  disabled                           = false
+  display_name                       = local.github_pool_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_pool[0].workload_identity_pool_id
+  workload_identity_pool_provider_id = local.github_pool_id
+
+  attribute_mapping = {
+    "google.subject" = "assertion.sub",
+  }
+
+  oidc {
+    issuer_uri        = local.github_issuer_uri
+  }
+}
+
+resource "google_service_account_iam_member" "github_service_account_user" {
+  count = local.add_github_workload_identity_federation ? 1 : 0
+
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${local.resource_email_static}"
+  # Allow all principals that match the provider's condition to impersonate this service account
+  member = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_pool[0].name}/*"
+  role   = "roles/iam.workloadIdentityUser"
+}


### PR DESCRIPTION
Add a workload identity federation pool and provider for this service account, usable in workflows from the provided repository/environment combination