### PR TITLE
Allow multiple workload identity federations

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -103,9 +103,11 @@ variable "github_secret_create" {
 
 variable "github_workload_identity_federation" {
   description = "Workload identity federation configs for Github Actions"
-  type = object({
-    environment = optional(string, "")
-    repository  = optional(string, "/")
-  })
-  default = {}
+  type = list(
+    object({
+      environment = optional(string, "")
+      repository  = optional(string, "/")
+    })
+  )
+  default = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.15.1"
+      version = ">= 5.18.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/workload-identity-federation.tf
+++ b/workload-identity-federation.tf
@@ -1,38 +1,38 @@
 locals {
-  github_repository = var.github_workload_identity_federation.repository
-  # github_actions_environment_variable expects repo name only, owner is inferred by the provider
-  repo_name                               = split("/", local.github_repository)[1]
-  github_environment                      = var.github_workload_identity_federation.environment
-  add_github_workload_identity_federation = length(compact([local.github_repository, local.github_environment])) == 2 ? 1 : 0
-  github_pool_id                          = substr("${split("/", local.github_repository)[1]}-${var.name}", 0, 32)
-  # only allow workflows from this repository/environment combination to impersonate this service account
-  github_attribute_condition = "assertion.repository == \"${local.github_repository}\" && assertion.environment == \"${local.github_environment}\""
-  github_issuer_uri          = "https://token.actions.githubusercontent.com"
-  formatted_account_id       = upper(replace(local.account_id, "-", "_"))
+  workload_identity_federation_configs = {
+    for o in var.github_workload_identity_federation : "${o.repository}/${o.environment}" => merge(o, {
+      # github_actions_environment_variable expects repo name only, owner is inferred by the provider
+      repo_name = split("/", o.repository)[1]
+      pool_id   = substr("${split("/", o.repository)[1]}-${var.name}", 0, 32)
+    }) if length(compact([o.repository, o.environment])) == 2
+  }
+
+  github_issuer_uri    = "https://token.actions.githubusercontent.com"
+  formatted_account_id = upper(replace(local.account_id, "-", "_"))
 }
 
-resource "google_iam_workload_identity_pool" "github_pool" {
-  count    = local.add_github_workload_identity_federation
+resource "google_iam_workload_identity_pool" "github_pools" {
+  for_each = local.workload_identity_federation_configs
   provider = google-beta
 
   project                   = var.project_id
-  workload_identity_pool_id = local.github_pool_id
-  display_name              = local.github_pool_id
+  workload_identity_pool_id = each.value.pool_id
+  display_name              = each.value.pool_id
   description               = "Workload Identity Federation Pool managed by Terraform"
   disabled                  = false
 }
 
-resource "google_iam_workload_identity_pool_provider" "provider" {
-  count    = local.add_github_workload_identity_federation
+resource "google_iam_workload_identity_pool_provider" "providers" {
+  for_each = local.workload_identity_federation_configs
   provider = google-beta
 
   project                            = var.project_id
-  attribute_condition                = local.github_attribute_condition
+  attribute_condition                = "assertion.repository == \"${each.value.repo_name}\" && assertion.environment == \"${each.value.environment}\""
   description                        = "Workload Identity Federation Pool Provider managed by Terraform"
   disabled                           = false
-  display_name                       = local.github_pool_id
-  workload_identity_pool_id          = google_iam_workload_identity_pool.github_pool[0].workload_identity_pool_id
-  workload_identity_pool_provider_id = local.github_pool_id
+  display_name                       = each.value.pool_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_pools[each.key].workload_identity_pool_id
+  workload_identity_pool_provider_id = each.value.pool_id
 
   attribute_mapping = {
     "google.subject" = "assertion.sub",
@@ -43,27 +43,27 @@ resource "google_iam_workload_identity_pool_provider" "provider" {
   }
 }
 
-resource "google_service_account_iam_member" "github_service_account_user" {
-  count = local.add_github_workload_identity_federation
+resource "google_service_account_iam_member" "github_service_account_users" {
+  for_each = local.workload_identity_federation_configs
 
   service_account_id = local.service_account.name
   # Allow all principals that match the provider's condition to impersonate this service account
-  member = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_pool[0].name}/*"
+  member = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_pools[each.key].name}/*"
   role   = "roles/iam.workloadIdentityUser"
 }
 
-resource "github_actions_environment_variable" "service_account_github_environment_variable" {
-  count         = local.add_github_workload_identity_federation
-  repository    = local.repo_name
-  environment   = local.github_environment
+resource "github_actions_environment_variable" "service_account_github_environment_variables" {
+  for_each      = local.workload_identity_federation_configs
+  repository    = each.value.repo_name
+  environment   = each.value.environment
   variable_name = "${local.formatted_account_id}_SERVICE_ACCOUNT"
   value         = local.service_account.email
 }
 
-resource "github_actions_environment_variable" "workload_identity_provider_github_environment_variable" {
-  count         = local.add_github_workload_identity_federation
-  repository    = local.repo_name
-  environment   = local.github_environment
+resource "github_actions_environment_variable" "workload_identity_provider_github_environment_variables" {
+  for_each      = local.workload_identity_federation_configs
+  repository    = each.value.repo_name
+  environment   = each.value.environment
   variable_name = "${local.formatted_account_id}_WORKLOAD_IDENTITY_PROVIDER"
-  value         = google_iam_workload_identity_pool_provider.provider[0].name
+  value         = google_iam_workload_identity_pool_provider.providers[each.key].name
 }


### PR DESCRIPTION
Allow creating multiple workload identity providers for the same service account for different repos/environments