### PR TITLE
feat: optional GitHub environment creation in WIF config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module allows simplified creation and management of one a service account and its IAM bindings. A key can optionally be generated and will be stored in Terraform state. To use it create a sensitive output in your root modules referencing the `key` output, then extract the private key from the JSON formatted outputs.
 
-A Github workload identity pool and provider can also be created by setting `github_workload_identity_federation`. The module will also create `<service-account-name>_SERVICE_ACCOUNT` and `<service-account-name>_WORKLOAD_IDENTITY_PROVIDER` Github Environment variables that you can reference from your Github Actions Workflow.
+A Github workload identity pool and provider can also be created by setting `github_workload_identity_federation`. The module will also create `<service-account-name>_SERVICE_ACCOUNT` and `<service-account-name>_WORKLOAD_IDENTITY_PROVIDER` Github Environment variables that you can reference from your Github Actions Workflow. Optionally, set `create_environment = true` within the `github_workload_identity_federation` block to have the module create the GitHub environment automatically. Use `environment_config` to configure reviewers, wait timers, and deployment branch policies.
 
 ## Example
 
@@ -23,6 +23,36 @@ module "myproject-default-service-accounts" {
       "roles/monitoring.metricWriter",
     ]
   }
+}
+```
+
+## Example with Github Environment Creation
+
+```hcl
+module "myproject-default-service-accounts" {
+  source     = "github.com/dapperlabs-platform/terraform-google-iam-service-account?ref=tag"
+  project_id = "myproject"
+  name       = "deploy-sa"
+
+  github_workload_identity_federation = [
+    {
+      environment        = "production"
+      repository         = "myorg/myrepo"
+      create_environment = true
+      environment_config = {
+        reviewers = [
+          {
+            teams = [123456]
+          }
+        ]
+        wait_timer = 5
+        deployment_branch_policy = {
+          protected_branches     = true
+          custom_branch_policies = false
+        }
+      }
+    }
+  ]
 }
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -119,8 +119,22 @@ variable "github_workload_identity_federation" {
   description = "Workload identity federation configs for Github Actions"
   type = list(
     object({
-      environment = optional(string, "")
-      repository  = optional(string, "/")
+      environment        = optional(string, "")
+      repository         = optional(string, "/")
+      create_environment = optional(bool, false)
+      environment_config = optional(object({
+        reviewers = optional(list(object({
+          users = optional(list(number), [])
+          teams = optional(list(number), [])
+        })), [])
+        wait_timer          = optional(number, 0)
+        can_admins_bypass   = optional(bool, true)
+        prevent_self_review = optional(bool, false)
+        deployment_branch_policy = optional(object({
+          protected_branches     = bool
+          custom_branch_policies = bool
+        }), null)
+      }), null)
     })
   )
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -138,4 +138,12 @@ variable "github_workload_identity_federation" {
     })
   )
   default = []
+
+  validation {
+    condition = alltrue([
+      for o in var.github_workload_identity_federation :
+      !o.create_environment || (o.environment != null && o.environment != "")
+    ])
+    error_message = "environment must be set to a non-empty string when create_environment is true."
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.18.0"
+      version = ">= 5.31.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/workload-identity-federation.tf
+++ b/workload-identity-federation.tf
@@ -87,7 +87,9 @@ resource "github_actions_environment_variable" "service_account_github_environme
   environment   = each.value.environment
   variable_name = "${local.formatted_account_id}_SERVICE_ACCOUNT"
   value         = local.service_account.email
-  depends_on    = [github_repository_environment.environments]
+  # depends_on is resource-level, not per-instance. All environment variables
+  # wait on all environment creations, even if only a subset use create_environment.
+  depends_on = [github_repository_environment.environments]
 }
 
 resource "github_actions_environment_variable" "workload_identity_provider_github_environment_variables" {
@@ -96,5 +98,7 @@ resource "github_actions_environment_variable" "workload_identity_provider_githu
   environment   = each.value.environment
   variable_name = "${local.formatted_account_id}_WORKLOAD_IDENTITY_PROVIDER"
   value         = google_iam_workload_identity_pool_provider.providers[each.key].name
-  depends_on    = [github_repository_environment.environments]
+  # depends_on is resource-level, not per-instance. All environment variables
+  # wait on all environment creations, even if only a subset use create_environment.
+  depends_on = [github_repository_environment.environments]
 }

--- a/workload-identity-federation.tf
+++ b/workload-identity-federation.tf
@@ -28,7 +28,7 @@ resource "github_repository_environment" "environments" {
   }
 
   wait_timer          = try(each.value.environment_config.wait_timer, 0)
-  can_admins_bypass   = try(each.value.environment_config.can_admins_bypass, true)
+  can_admins_bypass   = try(each.value.environment_config.can_admins_bypass, false)
   prevent_self_review = try(each.value.environment_config.prevent_self_review, false)
 
   dynamic "deployment_branch_policy" {
@@ -87,8 +87,7 @@ resource "github_actions_environment_variable" "service_account_github_environme
   environment   = each.value.environment
   variable_name = "${local.formatted_account_id}_SERVICE_ACCOUNT"
   value         = local.service_account.email
-  # depends_on is resource-level, not per-instance. All environment variables
-  # wait on all environment creations, even if only a subset use create_environment.
+
   depends_on = [github_repository_environment.environments]
 }
 
@@ -98,7 +97,6 @@ resource "github_actions_environment_variable" "workload_identity_provider_githu
   environment   = each.value.environment
   variable_name = "${local.formatted_account_id}_WORKLOAD_IDENTITY_PROVIDER"
   value         = google_iam_workload_identity_pool_provider.providers[each.key].name
-  # depends_on is resource-level, not per-instance. All environment variables
-  # wait on all environment creations, even if only a subset use create_environment.
+
   depends_on = [github_repository_environment.environments]
 }


### PR DESCRIPTION
## Summary

- Adds `create_environment` (bool, default `false`) and `environment_config` (optional object) to the `github_workload_identity_federation` variable
- When `create_environment = true`, creates a `github_repository_environment` resource with configurable reviewers, wait timer, deployment branch policy, and other settings
- Environment variable resources now depend on environment creation for correct ordering
- Adds validation to ensure `environment` is non-empty when `create_environment = true`
- Bumps minimum GitHub provider version to `>= 5.31.0` (required for `prevent_self_review` attribute)
- Fully backward compatible -- existing callers are unaffected

## Usage

```hcl
github_workload_identity_federation = [
  {
    environment        = "production"
    repository         = "myorg/myrepo"
    create_environment = true
    environment_config = {
      reviewers = [{ teams = [123456] }]
      wait_timer = 5
      deployment_branch_policy = {
        protected_branches     = true
        custom_branch_policies = false
      }
    }
  }
]
```

## Test plan

- [ ] Existing callers with `create_environment` omitted (defaults to `false`) produce no plan changes
- [ ] Setting `create_environment = true` with no `environment_config` creates a bare environment
- [ ] Setting `create_environment = true` with full `environment_config` creates environment with all protection rules
- [ ] Setting `create_environment = true` with empty `environment` fails validation
- [ ] `terraform validate` passes
- [ ] `terraform fmt -check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)